### PR TITLE
fix: Remove lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "chalk": "^2.3.2",
     "figures": "^2.0.0",
-    "lodash": "^4.17.5",
+    "lodash.startcase": "^4.4.0",
     "std-env": "^1.1.0"
   },
   "devDependencies": {

--- a/src/reporters/fancy.js
+++ b/src/reporters/fancy.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import figures from 'figures'
-import startCase from 'lodash/startCase'
+import startCase from 'lodash.startCase'
 
 const NS_SEPARATOR = chalk.blue(figures(' › '))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,6 +2447,10 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
+lodash.startcase@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
+
 lodash.template@^4.0.2:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
@@ -2464,7 +2468,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.14.0, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 


### PR DESCRIPTION
There is no need to pull in all of lodash (1.1MB install size) for just 1 function.

I'm creating a companion PR to remove it from webpackbar too :+1: