### PR TITLE
fix: expose typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "nuxt/consola",
   "main": "index.js",
   "browser": "dist/consola.js",
+  "typings": "types/consola.d.ts",
   "scripts": {
     "build": "yarn build:cjs && yarn build:browser",
     "build:cjs": "bili -t node --format cjs src/index.js",
@@ -19,7 +20,8 @@
   },
   "files": [
     "dist",
-    "index.js"
+    "index.js",
+    "types"
   ],
   "keywords": [
     "console",


### PR DESCRIPTION
Hi,

I saw you had typescript typings, but they never got shipped with the package nor exposed.