### PR TITLE
fix(reporters): Add a default value to the JSONReporter constructor

### DIFF
--- a/src/reporters/json.js
+++ b/src/reporters/json.js
@@ -1,5 +1,5 @@
 export default class JSONReporter {
-  constructor ({ stream }) {
+  constructor ({ stream } = {}) {
     this.stream = stream || process.stdout
   }
 


### PR DESCRIPTION
At the moment, calling `new JSONReporter()` throws the following error : `Cannot destructure property stream of 'undefined' or 'null'`

This is because of this line : `constructor ({ stream })`, where you destructure the argument. If no argument is given, the code crashes. 

This PR applies a default value (en empty object) to the argument, so we don't have to pass an empty object to instanciate the `JSONReporter`.

After this update, all the following works as expected. 

- `new JSONReporter()`
- `new JSONReporter({})`
- `new JSONReporter({ stream: <variable> })`