### PR TITLE
fix(ts): set message type to "any"

### DIFF
--- a/types/consola.d.ts
+++ b/types/consola.d.ts
@@ -1,14 +1,14 @@
 declare class Consola {
-    static fatal (message: string): void;
-    static error (message: string): void;
-    static warn (message: string): void;
-    static log (message: string): void;
-    static info (message: string): void;
-    static start (message: string): void;
-    static success (message: string): void;
-    static ready (message: string): void;
-    static debug (message: string): void;
-    static trace (message: string): void;
+    static fatal (message: any): void;
+    static error (message: any): void;
+    static warn (message: any): void;
+    static log (message: any): void;
+    static info (message: any): void;
+    static start (message: any): void;
+    static success (message: any): void;
+    static ready (message: any): void;
+    static debug (message: any): void;
+    static trace (message: any): void;
     static addReporter (reporter: (message: string) => void): (typeof Consola);
     static removeReporter (): (typeof Consola);
     static withTag (tag: string): (typeof Consola);


### PR DESCRIPTION
Consola supports logging for all types. Updates typings to allow `message` to be of type `any`.

Closes #38