### PR TITLE
fix(ts): set type "any" explicitly

### DIFF
--- a/types/consola.d.ts
+++ b/types/consola.d.ts
@@ -1,5 +1,5 @@
 declare interface ConsolaReporter {
-    log: (logObj, { async, stdout, stderr }) => void
+    log: (logObj: any, { async, stdout, stderr }: any) => void
 }
 
 declare class Consola {
@@ -46,8 +46,8 @@ declare class Consola {
     static resume(): void;
 
     // Mock
-    static mockTypes(mockFn: any);
-    static mock(mockFn: any);
+    static mockTypes(mockFn: any): any;
+    static mock(mockFn: any): any;
 }
 
 declare module "consola" {


### PR DESCRIPTION
I got some errors regarding "noImplicitAny" rule when building with TypeScript.
To solve this problem, I modified to add `any` type to several definition explicitly.

## Build Errors
```
2:11 Parameter 'logObj' implicitly has an 'any' type.
    1 | declare interface ConsolaReporter {
  > 2 |     log: (logObj, { async, stdout, stderr }) => void
      |           ^
    3 | }
    4 |
    5 | declare class Consola {

2:21 Binding element 'async' implicitly has an 'any' type.
    1 | declare interface ConsolaReporter {
  > 2 |     log: (logObj, { async, stdout, stderr }) => void
      |                     ^
    3 | }
    4 |
    5 | declare class Consola {

2:28 Binding element 'stdout' implicitly has an 'any' type.
    1 | declare interface ConsolaReporter {
  > 2 |     log: (logObj, { async, stdout, stderr }) => void
      |                            ^
    3 | }
    4 |
    5 | declare class Consola {

2:36 Binding element 'stderr' implicitly has an 'any' type.
    1 | declare interface ConsolaReporter {
  > 2 |     log: (logObj, { async, stdout, stderr }) => void
      |                                    ^
    3 | }
    4 |
    5 | declare class Consola {

49:12 'mockTypes', which lacks return-type annotation, implicitly has an 'any' return type.
    47 |
    48 |     // Mock
  > 49 |     static mockTypes(mockFn: any);
       |            ^
    50 |     static mock(mockFn: any);
    51 | }
    52 |

50:12 'mock', which lacks return-type annotation, implicitly has an 'any' return type.
    48 |     // Mock
    49 |     static mockTypes(mockFn: any);
  > 50 |     static mock(mockFn: any);
       |            ^
    51 | }
    52 |
    53 | declare module "consola" {

 ERROR  Nuxt Build Error