### PR TITLE
fix(ts): export consola ts declarations

### DIFF
--- a/types/consola.d.ts
+++ b/types/consola.d.ts
@@ -1,8 +1,8 @@
-declare interface ConsolaReporter {
+export declare interface ConsolaReporter {
     log: (logObj: any, { async, stdout, stderr }: any) => void
 }
 
-declare class Consola {
+export declare class Consola {
     // Built-in log levels
     static fatal (message: any): void;
     static error (message: any): void;


### PR DESCRIPTION
In order to be able to use the Consola class as a type outside of this project, its declarations must be exported.