### PR TITLE
fix(ts): revert export consola ts declarations

### DIFF
--- a/types/consola.d.ts
+++ b/types/consola.d.ts
@@ -1,8 +1,8 @@
-export declare interface ConsolaReporter {
+declare interface ConsolaReporter {
     log: (logObj: any, { async, stdout, stderr }: any) => void
 }
 
-export declare class Consola {
+declare class Consola {
     // Built-in log levels
     static fatal (message: any): void;
     static error (message: any): void;


### PR DESCRIPTION
It appears this broke the consola declarations altogether. 😓
I'll do a little more testing locally before creating another PR fixing the declarations.

Sorry about that.