### PR TITLE
fix(types): allow passing extra arguments

### DIFF
--- a/types/consola.d.ts
+++ b/types/consola.d.ts
@@ -4,16 +4,16 @@ declare interface ConsolaReporter {
 
 declare class Consola {
   // Built-in log levels
-  static fatal(message: any, ...optionalParams: any[]): void
-  static error(message: any, ...optionalParams: any[]): void
-  static warn(message: any, ...optionalParams: any[]): void
-  static log(message: any, ...optionalParams: any[]): void
-  static info(message: any, ...optionalParams: any[]): void
-  static start(message: any, ...optionalParams: any[]): void
-  static success(message: any, ...optionalParams: any[]): void
-  static ready(message: any, ...optionalParams: any[]): void
-  static debug(message: any, ...optionalParams: any[]): void
-  static trace(message: any, ...optionalParams: any[]): void
+  static fatal(message: any, ...args: any[]): void
+  static error(message: any, ...args: any[]): void
+  static warn(message: any, ...args: any[]): void
+  static log(message: any, ...args: any[]): void
+  static info(message: any, ...args: any[]): void
+  static start(message: any, ...args: any[]): void
+  static success(message: any, ...args: any[]): void
+  static ready(message: any, ...args: any[]): void
+  static debug(message: any, ...args: any[]): void
+  static trace(message: any, ...args: any[]): void
 
   // Create
   static create(options: any): typeof Consola

--- a/types/consola.d.ts
+++ b/types/consola.d.ts
@@ -1,55 +1,55 @@
 declare interface ConsolaReporter {
-    log: (logObj: any, { async, stdout, stderr }: any) => void
+  log: (logObj: any, { async, stdout, stderr }: any) => void
 }
 
 declare class Consola {
-    // Built-in log levels
-    static fatal (message: any): void;
-    static error (message: any): void;
-    static warn (message: any): void;
-    static log (message: any): void;
-    static info (message: any): void;
-    static start (message: any): void;
-    static success (message: any): void;
-    static ready (message: any): void;
-    static debug (message: any): void;
-    static trace(message: any): void;
+  // Built-in log levels
+  static fatal(message: any, ...optionalParams: any[]): void
+  static error(message: any, ...optionalParams: any[]): void
+  static warn(message: any, ...optionalParams: any[]): void
+  static log(message: any, ...optionalParams: any[]): void
+  static info(message: any, ...optionalParams: any[]): void
+  static start(message: any, ...optionalParams: any[]): void
+  static success(message: any, ...optionalParams: any[]): void
+  static ready(message: any, ...optionalParams: any[]): void
+  static debug(message: any, ...optionalParams: any[]): void
+  static trace(message: any, ...optionalParams: any[]): void
 
-    // Create
-    static create(options: any): (typeof Consola);
-    static withDefaults(defaults: any): (typeof Consola);
+  // Create
+  static create(options: any): typeof Consola
+  static withDefaults(defaults: any): typeof Consola
 
-    static withTag(tag: string): (typeof Consola);
-    static withScope(tag: string): (typeof Consola);
+  static withTag(tag: string): typeof Consola
+  static withScope(tag: string): typeof Consola
 
-    // Reporter
-    static addReporter(reporter: ConsolaReporter): (typeof Consola);
-    static setReporters(reporters: Array<ConsolaReporter>): (typeof Consola);
+  // Reporter
+  static addReporter(reporter: ConsolaReporter): typeof Consola
+  static setReporters(reporters: Array<ConsolaReporter>): typeof Consola
 
-    static removeReporter(reporter: any): (typeof Consola);
-    static remove(reporter: any): (typeof Consola);
-    static clear(reporter: any): (typeof Consola);
+  static removeReporter(reporter: any): typeof Consola
+  static remove(reporter: any): typeof Consola
+  static clear(reporter: any): typeof Consola
 
-    // Wrappers
-    static wrapAll(): void;
-    static restoreAll(): void;
-    static wrapConsole(): void;
-    static restoreConsole(): void;
-    static wrapStd(): void;
-    static restoreStd(): void;
+  // Wrappers
+  static wrapAll(): void
+  static restoreAll(): void
+  static wrapConsole(): void
+  static restoreConsole(): void
+  static wrapStd(): void
+  static restoreStd(): void
 
-    // Pause/Resume
-    static pauseLogs(): void;
-    static pause(): void;
+  // Pause/Resume
+  static pauseLogs(): void
+  static pause(): void
 
-    static resumeLogs(): void;
-    static resume(): void;
+  static resumeLogs(): void
+  static resume(): void
 
-    // Mock
-    static mockTypes(mockFn: any): any;
-    static mock(mockFn: any): any;
+  // Mock
+  static mockTypes(mockFn: any): any
+  static mock(mockFn: any): any
 }
 
-declare module "consola" {
-    export default Consola;
+declare module 'consola' {
+  export default Consola
 }


### PR DESCRIPTION
Adapted all log functions to have the same signature as console.log
Also reindented the whole thing with 2 spaces (as the rest of the
project)

tell me if you want the previous style back (I pretty much automatically formatted the file)