### PR TITLE
fix(browser): use `console.warn` when possible

### DIFF
--- a/src/reporters/browser.js
+++ b/src/reporters/browser.js
@@ -8,7 +8,9 @@ export default class BrowserReporter {
   log (logObj) {
     const consoleLogFn = logObj.level < 1
       // eslint-disable-next-line no-console
-      ? (console.__error || console.error) : (console.__log || console.log)
+      ? (console.__error || console.error)
+      // eslint-disable-next-line no-console
+      : logObj.level === 1 && console.warn ? (console.__warn || console.warn) : (console.__log || console.log)
 
     // Type
     const type = logObj.type !== 'log' ? `[${logObj.type.toUpperCase()}]` : ''


### PR DESCRIPTION
Before:
<img width="837" alt="Screenshot 2019-05-08 at 17 50 20" src="https://user-images.githubusercontent.com/904724/57389096-c46ee080-71b9-11e9-9313-781440dc7195.png">

After:
<img width="851" alt="Screenshot 2019-05-08 at 17 49 40" src="https://user-images.githubusercontent.com/904724/57389101-c638a400-71b9-11e9-99aa-3e34675bca86.png">
