### PR TITLE
feat(browser): add support of formatted strings

### DIFF
--- a/src/reporters/browser.js
+++ b/src/reporters/browser.js
@@ -27,7 +27,6 @@ export default class BrowserReporter {
     const tag = logObj.tag ? logObj.tag : ''
 
     // Styles
-
     const color = this.typeColorMap[logObj.type] || this.levelColorMap[logObj.level] || this.defaultColor
     const style = `
       background: ${color};
@@ -38,10 +37,15 @@ export default class BrowserReporter {
     `
 
     // Log to the console
-    consoleLogFn(
-      '%c' + [tag, type].filter(Boolean).join(':'),
-      style,
-      ...logObj.args
-    )
+    if (typeof logObj.args[0] === 'string') {
+      consoleLogFn(
+        `%c${[tag, type].filter(Boolean).join(':')}%c ${logObj.args[0]}`,
+        style,
+        '',
+        ...logObj.args.slice(1)
+      )
+    } else {
+      consoleLogFn(`%c${[tag, type].filter(Boolean).join(':')}`, style, ...logObj.args)
+    }
   }
 }

--- a/src/reporters/browser.js
+++ b/src/reporters/browser.js
@@ -43,6 +43,7 @@ export default class BrowserReporter {
       consoleLogFn(
         `${badge}%c ${logObj.args[0]}`,
         style,
+        // Empty string as style resets to default console style
         '',
         ...logObj.args.slice(1)
       )

--- a/src/reporters/browser.js
+++ b/src/reporters/browser.js
@@ -36,16 +36,18 @@ export default class BrowserReporter {
       padding: 2px 0.5em;
     `
 
+    const badge = `%c${[tag, type].filter(Boolean).join(':')}`
+
     // Log to the console
     if (typeof logObj.args[0] === 'string') {
       consoleLogFn(
-        `%c${[tag, type].filter(Boolean).join(':')}%c ${logObj.args[0]}`,
+        `${badge}%c ${logObj.args[0]}`,
         style,
         '',
         ...logObj.args.slice(1)
       )
     } else {
-      consoleLogFn(`%c${[tag, type].filter(Boolean).join(':')}`, style, ...logObj.args)
+      consoleLogFn(badge, style, ...logObj.args)
     }
   }
 }


### PR DESCRIPTION
Hi,

Currently Consola does not support the usage of formatted strings with the `BrowserReporter`. Example, if you log with the following arguments:

```js
logger.error('Error: %s is not a valid configuration key', 'test')
```

It will output:

```
Error: %s is not a valid configuration key test
```

Instead of:

```
Error: test is not a valid configuration key
```

So in this PR, i made a small modification to add the support for this functionality.

Thanks