### PR TITLE
fix: include polyfills for browser build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,11 +14,14 @@
         [
           "@babel/preset-env",
           {
-            "useBuiltIns": "entry",
+            "targets": {
+              "ie": "9"
+            },
+            "useBuiltIns": "usage",
             "corejs": { "version": 2 }
           }
         ]
       ]
-    },
+    }
   }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -18,7 +18,7 @@
               "ie": "9"
             },
             "useBuiltIns": "usage",
-            "corejs": { "version": 2 }
+            "corejs": { "version": 3 }
           }
         ]
       ]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "rm -rf dist && yarn build:node && yarn build:browser",
     "build:node": "NODE_ENV=node bili src/node.js --file-name consola.js --format cjs --bundle-node-modules --minify --no-map",
-    "build:browser": "NODE_ENV=browser bili src/browser.js --file-name consola.browser.js --format umd --module-name consola --bundle-node-modules --minify --no-map",
+    "build:browser": "NODE_ENV=browser bili src/browser.js --file-name consola.browser.js --format umd --module-name consola --minify --no-map",
     "demo": "node demo",
     "browser": "serve",
     "test": "yarn lint && yarn test:types && yarn build && jest test",
@@ -48,6 +48,7 @@
     "benchmark": "^2.1.4",
     "bili": "^4.8.1",
     "chalk": "^2.4.2",
+    "core-js": "^2",
     "dayjs": "^1.8.15",
     "eslint": "^6.1.0",
     "eslint-config-standard": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "benchmark": "^2.1.4",
     "bili": "^4.8.1",
     "chalk": "^2.4.2",
-    "core-js": "^2",
+    "core-js": "^3",
     "dayjs": "^1.8.15",
     "eslint": "^6.1.0",
     "eslint-config-standard": "^14.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,6 +2035,11 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
+core-js@^2:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
+  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,10 +2035,10 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
-core-js@^2:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
-  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+core-js@^3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
+  integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Current `consola.browser.js` doesn't include polyfill and can't be used directly in legacy browsers like IE11.

Changes:

- Change `useBuiltIns` to `usage` for adding polyfills
- remove `bundle-node-modules` in `browser` build, so `core-js` polyfills will be bundled instead of being `define(['core-js/...'])` which makes `consola.browser.js` can be used directly in browser via `<script src="...">`, @pi0 if `consola.browser.js` is not supposed to be used in browser directly but a node module, I can remove this, but the `umd` will be unnecessary then.

Side Effects:

Because this pr will introduce polyfills, so libs like Nuxt which have building phase cannot transform consola properly, but this is already a problem since `consola.browser.js` has transpiled all es2015+ syntax.

@pi0 Can we use `consola/src/browser.js` and `consola/src/node.js` directly in Nuxt for better transpiling ? If OK, I can make a PR