### PR TITLE
fix(types): const consola = require('consola') type is wrong

### DIFF
--- a/types/consola.d.ts
+++ b/types/consola.d.ts
@@ -94,3 +94,5 @@ export declare class BrowserReporter implements ConsolaReporter {
 declare const consolaGlobalInstance: Consola;
 
 export default consolaGlobalInstance
+
+export = consolaGlobalInstance


### PR DESCRIPTION
Fix a typing issue that causes this to throw a typing error on `consola.green`:

```js
// @ts-check

const consola = require('consola')

consola.green('foo')
```
